### PR TITLE
Clean cost and income repositories.

### DIFF
--- a/CostIncomeCalculator/Controllers/CostController.cs
+++ b/CostIncomeCalculator/Controllers/CostController.cs
@@ -72,33 +72,17 @@ namespace CostIncomeCalculator.Controllers
                     return Ok(costs);
                 }
                 else if (period != null)
-                {
-                    if (category == null)
-                    {   
-                        if (period == "weekly") {
-                            var costs = await repository.GetWeeklyCosts(email, date);
-                            return Ok(costs);
-                        }
-                        else if (period == "monthly")
-                        {
-                            var costs = await repository.GetMonthlyCosts(email, date);
-                            return Ok(costs);
-                        }
-                        return BadRequest();
+                {  
+                    if (period == "weekly") {
+                        var costs = await repository.GetWeeklyCosts(email, date, category);
+                        return Ok(costs);
                     }
-                    else
+                    else if (period == "monthly")
                     {
-                        if (period == "weekly") {
-                            var costs = await repository.GetWeeklyCostsByCategory(email, date, category);
-                            return Ok(costs);
-                        }
-                        else if (period == "monthly")
-                        {
-                            var costs = await repository.GetMonthlyCostsByCategory(email, date, category);
-                            return Ok(costs);
-                        }
-                        return BadRequest();
+                        var costs = await repository.GetMonthlyCosts(email, date, category);
+                        return Ok(costs);
                     }
+                    return BadRequest();
                 }
                 else 
                 {

--- a/CostIncomeCalculator/Controllers/IncomeController.cs
+++ b/CostIncomeCalculator/Controllers/IncomeController.cs
@@ -73,32 +73,16 @@ namespace CostIncomeCalculator.Controllers
                 }
                 else if (period != null)
                 {
-                    if (category == null)
-                    {   
-                        if (period == "weekly") {
-                            var costs = await repository.GetWeeklyIncomes(email, date);
-                            return Ok(costs);
-                        }
-                        else if (period == "monthly")
-                        {
-                            var costs = await repository.GetMonthlyIncomes(email, date);
-                            return Ok(costs);
-                        }
-                        return BadRequest();
+                    if (period == "weekly") {
+                        var costs = await repository.GetWeeklyIncomes(email, date, category);
+                        return Ok(costs);
                     }
-                    else
+                    else if (period == "monthly")
                     {
-                        if (period == "weekly") {
-                            var costs = await repository.GetWeeklyIncomesByCategory(email, date, category);
-                            return Ok(costs);
-                        }
-                        else if (period == "monthly")
-                        {
-                            var costs = await repository.GetMonthlyIncomesByCategory(email, date, category);
-                            return Ok(costs);
-                        }
-                        return BadRequest();
+                        var costs = await repository.GetMonthlyIncomes(email, date, category);
+                        return Ok(costs);
                     }
+                    return BadRequest();
                 }
                 else 
                 {

--- a/CostIncomeCalculator/Data/CostData/CostRepository.cs
+++ b/CostIncomeCalculator/Data/CostData/CostRepository.cs
@@ -90,50 +90,23 @@ namespace CostIncomeCalculator.Data.CostData
         /// </summary>
         /// <param name="email">User email</param>
         /// <param name="date">Date of the week</param>
+        /// <param name="category">Category to get costs. May be null.</param>
         /// <returns>Array of <see cref="CostReturnDto" /></returns>
-        public async Task<IEnumerable<CostReturnDto>> GetWeeklyCosts(string email, DateTime date)
+        public async Task<IEnumerable<CostReturnDto>> GetWeeklyCosts(string email, DateTime date, string category)
         {
             try
             {
                 (DateTime, DateTime) dates = datesHelper.GetWeekDateRange(date);
-                var weeklyCosts = await context.Costs
+                var weeklyCosts = context.Costs
                                         .Where(x =>
                                                 x.user.Email == email && 
                                                 x.Date >= dates.Item1.Date &&
                                                 x.Date <= dates.Item2.Date
-                                        ).ToListAsync();
+                                        );
 
-                return mapper.Map<IEnumerable<CostReturnDto>>(weeklyCosts);
-            }
-            catch (Exception e)
-            {
-                logger.Error(e.Message);
-                throw;
-            }
-        }
+                if (category != null) weeklyCosts.Where(x => x.Category.ToLower() == category.ToLower());
 
-        /// <summary>
-        /// Get weekly costs by category method.
-        /// </summary>
-        /// <param name="email">User email</param>
-        /// <param name="date">Date of the week</param>
-        /// <param name="category">Category to get costs.</param>
-        /// <returns>Array of <see cref="CostReturnDto" /></returns>
-        public async Task<IEnumerable<CostReturnDto>> GetWeeklyCostsByCategory(string email, DateTime date, string category)
-        {
-            try
-            {
-                (DateTime, DateTime) dates = datesHelper.GetWeekDateRange(date);
-                var weeklyCostsByCategory = await context.Costs
-                                                    .Where(x =>
-                                                            x.user.Email == email &&
-                                                            x.Date >= dates.Item1.Date &&
-                                                            x.Date <= dates.Item2.Date
-                                                    ).Where(x =>
-                                                            x.Category.ToLower() == category.ToLower()
-                                                    ).ToListAsync();
-
-                return mapper.Map<IEnumerable<CostReturnDto>>(weeklyCostsByCategory);
+                return mapper.Map<IEnumerable<CostReturnDto>>(await weeklyCosts.ToListAsync());
             }
             catch (Exception e)
             {
@@ -147,50 +120,23 @@ namespace CostIncomeCalculator.Data.CostData
         /// </summary>
         /// <param name="email">User email</param>
         /// <param name="date">Date of the week</param>
+        /// <param name="category">Category to get costs. May be null.</param>
         /// <returns>Array of <see cref="CostReturnDto" /></returns>
-        public async Task<IEnumerable<CostReturnDto>> GetMonthlyCosts(string email, DateTime date)
+        public async Task<IEnumerable<CostReturnDto>> GetMonthlyCosts(string email, DateTime date, string category)
         {
             try
             {
                 (DateTime, DateTime) dates = datesHelper.GetMonthDateRange(date);
-                var monthlyCosts = await context.Costs
+                var monthlyCosts = context.Costs
                                         .Where(x =>
                                                 x.user.Email == email &&
                                                 x.Date >= dates.Item1.Date &&
                                                 x.Date <= dates.Item2.Date
-                                        ).ToListAsync();
+                                        );
 
-                return mapper.Map<IEnumerable<CostReturnDto>>(monthlyCosts);
-            }
-            catch (Exception e)
-            {
-                logger.Error(e.Message);
-                throw;
-            }
-        }
+                if (category != null) monthlyCosts.Where(x => x.Category.ToLower() == category.ToLower());
 
-        /// <summary>
-        /// Get monthly costs by category method.
-        /// </summary>
-        /// <param name="email">User email</param>
-        /// <param name="date">Date of the week</param>
-        /// <param name="category">Category to get costs.</param>
-        /// <returns>Array of <see cref="CostReturnDto" /></returns>
-        public async Task<IEnumerable<CostReturnDto>> GetMonthlyCostsByCategory(string email, DateTime date, string category)
-        {
-            try
-            {
-                (DateTime, DateTime) dates = datesHelper.GetMonthDateRange(date);
-                var monthlyCostsByCategory = await context.Costs
-                                                .Where(x =>
-                                                        x.user.Email == email &&
-                                                        x.Date >= dates.Item1.Date &&
-                                                        x.Date <= dates.Item2.Date)
-                                                .Where(x =>
-                                                        x.Category.ToLower() == category.ToLower()
-                                                ).ToListAsync();
-
-                return mapper.Map<IEnumerable<CostReturnDto>>(monthlyCostsByCategory);
+                return mapper.Map<IEnumerable<CostReturnDto>>(await monthlyCosts.ToListAsync());
             }
             catch (Exception e)
             {

--- a/CostIncomeCalculator/Data/CostData/ICostRepository.cs
+++ b/CostIncomeCalculator/Data/CostData/ICostRepository.cs
@@ -31,34 +31,18 @@ namespace CostIncomeCalculator.Data.CostData
         /// </summary>
         /// <param name="email">User email</param>
         /// <param name="date">Date of the week</param>
+        /// <param name="category">Category to get costs. May be null.</param>
         /// <returns>Array of <see cref="CostReturnDto" /></returns>
-        Task<IEnumerable<CostReturnDto>> GetWeeklyCosts(string email, DateTime date);
-
-        /// <summary>
-        /// Get weekly costs by category. See implementation here <see cref="CostRepository.GetWeeklyCostsByCategory" />.
-        /// </summary>
-        /// <param name="email">User email</param>
-        /// <param name="date">Date of the week</param>
-        /// <param name="category">Category to get costs.</param>
-        /// <returns>Array of <see cref="CostReturnDto" /></returns>
-        Task<IEnumerable<CostReturnDto>> GetWeeklyCostsByCategory(string email, DateTime date, string category);
+        Task<IEnumerable<CostReturnDto>> GetWeeklyCosts(string email, DateTime date, string category);
 
         /// <summary>
         /// Get monthly costs. See implementation here <see cref="CostRepository.GetMonthlyCosts" />.
         /// </summary>
         /// <param name="email">User email</param>
         /// <param name="date">Date of the month</param>
+        /// <param name="category">Category to get costs. May be null.</param>
         /// <returns>Array of <see cref="CostReturnDto" /></returns>
-        Task<IEnumerable<CostReturnDto>> GetMonthlyCosts(string email, DateTime date);
-
-        /// <summary>
-        /// Get monthly costs by category. See implementation here <see cref="CostRepository.GetMonthlyCostsByCategory" />.
-        /// </summary>
-        /// <param name="email">User email</param>
-        /// <param name="date">Date of the week</param>
-        /// <param name="category">Category to get costs.</param>
-        /// <returns>Array of <see cref="CostReturnDto" /></returns>
-        Task<IEnumerable<CostReturnDto>> GetMonthlyCostsByCategory(string email, DateTime date, string category);
+        Task<IEnumerable<CostReturnDto>> GetMonthlyCosts(string email, DateTime date, string category);
         
         /// <summary>
         /// Set cost method. See implementation here <see cref="CostRepository.SetCost" />.

--- a/CostIncomeCalculator/Data/IncomeData/IIncomeRepository.cs
+++ b/CostIncomeCalculator/Data/IncomeData/IIncomeRepository.cs
@@ -31,34 +31,18 @@ namespace CostIncomeCalculator.Data.IncomeData
         /// </summary>
         /// <param name="email">User email</param>
         /// <param name="date">Date of the week</param>
+        /// <param name="category">Category to get incomes. May be null.</param>
         /// <returns>Array of <see cref="IncomeReturnDto" /></returns>
-        Task<IEnumerable<IncomeReturnDto>> GetWeeklyIncomes(string email, DateTime date);
-
-        /// <summary>
-        /// Get weekly incomes by category. See implementation here <see cref="IncomeRepository.GetWeeklyIncomesByCategory" />.
-        /// </summary>
-        /// <param name="email">User email</param>
-        /// <param name="date">Date of the week</param>
-        /// <param name="category">Category to get incomes.</param>
-        /// <returns>Array of <see cref="IncomeReturnDto" /></returns>
-        Task<IEnumerable<IncomeReturnDto>> GetWeeklyIncomesByCategory(string email, DateTime date, string category);
+        Task<IEnumerable<IncomeReturnDto>> GetWeeklyIncomes(string email, DateTime date, string category);
 
         /// <summary>
         /// Get monthly incomes. See implementation here <see cref="IncomeRepository.GetMonthlyIncomes" />.
         /// </summary>
         /// <param name="email">User email</param>
         /// <param name="date">Date of the week</param>
+        /// /// <param name="category">Category to get incomes. May be null.</param>
         /// <returns>Array of <see cref="IncomeReturnDto" /></returns>
-        Task<IEnumerable<IncomeReturnDto>> GetMonthlyIncomes(string email, DateTime date);
-
-        /// <summary>
-        /// Get monthly incomes by category. See implementation here <see cref="IncomeRepository.GetMonthlyIncomesByCategory" />.
-        /// </summary>
-        /// <param name="email">User email</param>
-        /// <param name="date">Date of the week</param>
-        /// <param name="category">Category to get incomes.</param>
-        /// <returns>Array of <see cref="IncomeReturnDto" /></returns>
-        Task<IEnumerable<IncomeReturnDto>> GetMonthlyIncomesByCategory(string email, DateTime date, string category);
+        Task<IEnumerable<IncomeReturnDto>> GetMonthlyIncomes(string email, DateTime date, string category);
 
         /// <summary>
         /// Set income method. See implementation here <see cref="IncomeRepository.SetIncome" />.

--- a/CostIncomeCalculator/Data/IncomeData/IncomeRepository.cs
+++ b/CostIncomeCalculator/Data/IncomeData/IncomeRepository.cs
@@ -90,20 +90,23 @@ namespace CostIncomeCalculator.Data.IncomeData
         /// </summary>
         /// <param name="email">User email</param>
         /// <param name="date">Date of the week</param>
+        /// <param name="category">Category to get incomes. May be null.</param>
         /// <returns>Array of <see cref="IncomeReturnDto" /></returns>
-        public async Task<IEnumerable<IncomeReturnDto>> GetWeeklyIncomes(string email, DateTime date)
+        public async Task<IEnumerable<IncomeReturnDto>> GetWeeklyIncomes(string email, DateTime date, string category)
         {
             try
             {
                 (DateTime, DateTime) dates = datesHelper.GetMonthDateRange(date);
-                var weeklyIncomes = await context.Incomes
+                var weeklyIncomes = context.Incomes
                                             .Where(x =>
                                                     x.user.Email == email &&
                                                     x.Date >= dates.Item1.Date &&
                                                     x.Date <= dates.Item2.Date
-                                            ).ToListAsync();
+                                            );
 
-                return mapper.Map<IEnumerable<IncomeReturnDto>>(weeklyIncomes);
+                if (category != null) weeklyIncomes.Where(x => x.Category.ToLower() == category.ToLower());
+
+                return mapper.Map<IEnumerable<IncomeReturnDto>>(await weeklyIncomes.ToListAsync());
             }
             catch (Exception e)
             {
@@ -113,82 +116,25 @@ namespace CostIncomeCalculator.Data.IncomeData
         }
 
         /// <summary>
-        /// Get weekly incomes by category method.
+        /// Get monthly incomes method.
         /// </summary>
         /// <param name="email">User email</param>
         /// <param name="date">Date of the week</param>
-        /// <param name="category">Category to get incomes.</param>
+        /// <param name="category">Category to get incomes. May be null.</param>
         /// <returns>Array of <see cref="IncomeReturnDto" /></returns>
-        public async Task<IEnumerable<IncomeReturnDto>> GetWeeklyIncomesByCategory(string email, DateTime date, string category)
-        {
-            try
-            {
-                (DateTime, DateTime) dates = datesHelper.GetMonthDateRange(date);
-                var weeklyIncomesByCategory = await context.Incomes
-                                                        .Where(x =>
-                                                                x.user.Email == email &&
-                                                                x.Date >= dates.Item1.Date &&
-                                                                x.Date <= dates.Item2.Date
-                                                        ).Where(x =>
-                                                                x.Category.ToLower() == category.ToLower()
-                                                        ).ToListAsync();
-
-                return mapper.Map<IEnumerable<IncomeReturnDto>>(weeklyIncomesByCategory);
-            }
-            catch (Exception e)
-            {
-                logger.Error(e.Message);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Get monthly incomes methos.
-        /// </summary>
-        /// <param name="email">User email</param>
-        /// <param name="date">Date of the week</param>
-        /// <returns>Array of <see cref="IncomeReturnDto" /></returns>
-        public async Task<IEnumerable<IncomeReturnDto>> GetMonthlyIncomes(string email, DateTime date)
+        public async Task<IEnumerable<IncomeReturnDto>> GetMonthlyIncomes(string email, DateTime date, string category)
         {
             (DateTime, DateTime) dates = datesHelper.GetMonthDateRange(date);
-            var monthlyIncomes = await context.Incomes
+            var monthlyIncomes = context.Incomes
                                         .Where(x =>
                                                 x.user.Email == email &&
                                                 x.Date >= dates.Item1.Date &&
                                                 x.Date <= dates.Item2.Date
-                                        ).ToListAsync();
+                                        );
 
-            return mapper.Map<IEnumerable<IncomeReturnDto>>(monthlyIncomes);
-        }
+            if (category != null) monthlyIncomes.Where(x => x.Category.ToLower() == category.ToLower());
 
-        /// <summary>
-        /// Get monthly incomes by category method.
-        /// </summary>
-        /// <param name="email">User email</param>
-        /// <param name="date">Date of the week</param>
-        /// <param name="category">Category to get incomes.</param>
-        /// <returns>Array of <see cref="IncomeReturnDto" /></returns>
-        public async Task<IEnumerable<IncomeReturnDto>> GetMonthlyIncomesByCategory(string email, DateTime date, string category)
-        {
-            try
-            {
-                (DateTime, DateTime) dates = datesHelper.GetMonthDateRange(date);
-                var monthlyIncomesByCategory = await context.Incomes
-                                                    .Where(x =>
-                                                            x.user.Email == email &&
-                                                            x.Date >= dates.Item1.Date &&
-                                                            x.Date <= dates.Item2.Date
-                                                    ).Where(x =>
-                                                            x.Category.ToLower() == category.ToLower()
-                                                    ).ToListAsync();
-
-                return mapper.Map<IEnumerable<IncomeReturnDto>>(monthlyIncomesByCategory);
-            }
-            catch (Exception e)
-            {
-                logger.Error(e.Message);
-                throw;
-            }
+            return mapper.Map<IEnumerable<IncomeReturnDto>>(await monthlyIncomes.ToListAsync());
         }
 
         /// <summary>

--- a/CostIncomeCalculator/Dtos/CostDtos/CostReturnDto.cs
+++ b/CostIncomeCalculator/Dtos/CostDtos/CostReturnDto.cs
@@ -7,9 +7,7 @@ namespace CostIncomeCalculator.Dtos.CostDtos
     /// <see cref="Data.CostData.CostRepository.GetAllCosts"/>
     /// <see cref="Data.CostData.CostRepository.GetConcreteCost"/>
     /// <see cref="Data.CostData.CostRepository.GetWeeklyCosts"/>
-    /// <see cref="Data.CostData.CostRepository.GetWeeklyCostsByCategory"/>
     /// <see cref="Data.CostData.CostRepository.GetMonthlyCosts"/>
-    /// <see cref="Data.CostData.CostRepository.GetMonthlyCostsByCategory"/>
     /// </summary>
     public class CostReturnDto
     {

--- a/CostIncomeCalculator/Dtos/IncomeDtos/IncomeReturnDto.cs
+++ b/CostIncomeCalculator/Dtos/IncomeDtos/IncomeReturnDto.cs
@@ -7,9 +7,7 @@ namespace CostIncomeCalculator.Dtos.IncomeDtos
     /// <see cref="Data.IncomeData.IncomeRepository.GetAllIncomes"/>
     /// <see cref="Data.IncomeData.IncomeRepository.GetConcreteIncome"/>
     /// <see cref="Data.IncomeData.IncomeRepository.GetWeeklyIncomes"/>
-    /// <see cref="Data.IncomeData.IncomeRepository.GetWeeklyIncomesByCategory"/>
     /// <see cref="Data.IncomeData.IncomeRepository.GetMonthlyIncomes"/>
-    /// <see cref="Data.IncomeData.IncomeRepository.GetMonthlyIncomesByCategory"/>
     /// </summary>
     public class IncomeReturnDto
     {


### PR DESCRIPTION
This useless methods removed:
 - GetWeeklyCostsByCategory
 - GetMonthlyCostsByCategory
 - GetWeeklyIncomesByCategory
 - GetMonthlyIncomesByCategory

The cost and income controllers were changed after removing the methods
described above.

Fix docs in cost and income return dto.